### PR TITLE
Placeholder for simulator results folder

### DIFF
--- a/gaden_demo/demo/logs_gas_dispersion_simulator/placeholder.txt
+++ b/gaden_demo/demo/logs_gas_dispersion_simulator/placeholder.txt
@@ -1,0 +1,1 @@
+This is a placedholder file for the gas dispersion simulator results folder. I kept on getting an error, so I guess this dir is not created in the script.


### PR DESCRIPTION
I came across this issue the first time I ran the launch, I kept on getting an error: "Unable to open final output file". I did some digging and I think it happens because the dir where the simulator results are saved into doesn't exist and isn't created anywhere. Did I miss something? If the folder is already there no errors occur.