### PR TITLE
Account for several windspeed measurements falling on a single cell

### DIFF
--- a/gaden_demo/demo/openFoam_to_gaden.m
+++ b/gaden_demo/demo/openFoam_to_gaden.m
@@ -283,4 +283,4 @@ subplot(1,2,2);
 I2 = imresize(I,cell_resolution/final_res,'nearest');
 imshow(I2);
 % save to file
-imwrite(I2,'OccupancyMap2D.pgm');
+imwrite(I2,'MAPIRlab_furniture.pgm');

--- a/gaden_demo/demo/openFoam_to_gaden.m
+++ b/gaden_demo/demo/openFoam_to_gaden.m
@@ -283,4 +283,4 @@ subplot(1,2,2);
 I2 = imresize(I,cell_resolution/final_res,'nearest');
 imshow(I2);
 % save to file
-imwrite(I2,'MAPIRlab_furniture.pgm');
+imwrite(I2,'OccupancyMap2D.pgm');


### PR DESCRIPTION
**Problem:** If GADEN uses a lower spatial resolution than OpenFoam, several windspeed measurements may fall into a single cell. This is no problem if you use the same resolution for both simulations (say 10cm cubes).

**Fix:** I've updated the openFoam_to_gaden script to account for this by simply averaging all measurements that fall on a single GADEN cell.

**Q**: Is there any feature-request page or changelog I should update? I've already removed the appropriate ToDo lines in the script, but I'm unaware if there are other files that should be updated.