### PR TITLE
Fix boost dependency

### DIFF
--- a/gaden_player/src/simulation_player.cpp
+++ b/gaden_player/src/simulation_player.cpp
@@ -5,6 +5,7 @@
  * It also generates a point cloud representing the gas concentration [ppm] on the 3D environment
  --------------------------------------------------------------------------------*/
 
+#include <boost/format.hpp>
 #include "simulation_player.h"
 
 //--------------- SERVICES CALLBACKS----------------------//

--- a/simulated_anemometer/CMakeLists.txt
+++ b/simulated_anemometer/CMakeLists.txt
@@ -1,14 +1,16 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(simulated_anemometer)
 
-find_package(catkin REQUIRED COMPONENTS
+find_package(
+    catkin REQUIRED COMPONENTS
     roscpp
     visualization_msgs
     std_msgs
     nav_msgs
     olfaction_msgs
-    tf)
-
+    tf
+    gaden_player
+)
 
 FILE(GLOB_RECURSE MYFILES_CPP "src/*.cpp")
 
@@ -20,6 +22,7 @@ catkin_package(
     nav_msgs
     olfaction_msgs
     tf
+    gaden_player
 )
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})

--- a/simulated_anemometer/package.xml
+++ b/simulated_anemometer/package.xml
@@ -17,6 +17,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>olfaction_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>gaden_player</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>roscpp</run_depend>
@@ -25,5 +26,6 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>olfaction_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>gaden_player</run_depend>
 
 </package>

--- a/simulated_gas_sensor/CMakeLists.txt
+++ b/simulated_gas_sensor/CMakeLists.txt
@@ -4,19 +4,29 @@ cmake_minimum_required(VERSION 2.8.3)
 project(simulated_gas_sensor)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
-find_package(catkin REQUIRED COMPONENTS
-    roscpp
-    visualization_msgs
-    std_msgs
-    nav_msgs
-    olfaction_msgs
-    tf
-    pcl_ros)
+find_package(
+	catkin REQUIRED COMPONENTS
+	roscpp
+	visualization_msgs
+	std_msgs
+	nav_msgs
+	olfaction_msgs
+	tf
+	pcl_ros
+	gaden_player
+)
 
 FILE(GLOB_RECURSE MYFILES_CPP "src/*.cpp")
 
 catkin_package(
-        DEPENDS roscpp visualization_msgs std_msgs olfaction_msgs nav_msgs tf
+	DEPENDS 
+	roscpp
+	visualization_msgs
+	std_msgs
+	olfaction_msgs
+	nav_msgs
+	tf
+	gaden_player
 )
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})

--- a/simulated_gas_sensor/package.xml
+++ b/simulated_gas_sensor/package.xml
@@ -16,6 +16,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>olfaction_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>gaden_player</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>roscpp</run_depend>
@@ -24,5 +25,5 @@
   <run_depend>tf</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>olfaction_msgs</run_depend>
-
+  <run_depend>gaden_player</run_depend>
 </package>

--- a/simulated_gas_sensor_array/CMakeLists.txt
+++ b/simulated_gas_sensor_array/CMakeLists.txt
@@ -12,12 +12,20 @@ find_package(catkin REQUIRED COMPONENTS
     olfaction_msgs
     tf
     pcl_ros
+    gaden_player
 )
 
 FILE(GLOB_RECURSE MYFILES_CPP "src/*.cpp")
 
 catkin_package(
-        DEPENDS roscpp visualization_msgs std_msgs olfaction_msgs nav_msgs tf
+    DEPENDS
+    roscpp
+    visualization_msgs
+    std_msgs
+    olfaction_msgs
+    nav_msgs
+    tf
+    gaden_player
 )
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})

--- a/simulated_gas_sensor_array/package.xml
+++ b/simulated_gas_sensor_array/package.xml
@@ -16,6 +16,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>olfaction_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>gaden_player</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>roscpp</run_depend>
@@ -24,5 +25,6 @@
   <run_depend>tf</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>olfaction_msgs</run_depend>
+  <run_depend>gaden_player</run_depend>
 
 </package>


### PR DESCRIPTION
Add #include <boost/format.hpp> in simulation_player.cpp. There is a build problem possibly starting from boost 1.65 where the error says format is not a method in boost.

I tried to build this on Ubuntu 18.04, Ros melodic, boost 1.65.1.0ubuntu1.

Error:
     std::string filename = boost::str( boost::format("%s%i") % simulation_filename.c_str() % sim_iteration);
                                               ^~~~~~
                                               forward
gaden/gaden_player/CMakeFiles/gaden_player.dir/build.make:62: recipe for target 'gaden/gaden_player/CMakeFiles/gaden_player.dir/src/simulation_player.cpp.o' failed
make[2]: *** [gaden/gaden_player/CMakeFiles/gaden_player.dir/src/simulation_player.cpp.o] Error 1
CMakeFiles/Makefile2:4650: recipe for target 'gaden/gaden_player/CMakeFiles/gaden_player.dir/all' failed