### PR TITLE
fix typos in launchfiles

### DIFF
--- a/test_env/10x6_central_obstacle/launch/GADEN.launch
+++ b/test_env/10x6_central_obstacle/launch/GADEN.launch
@@ -4,7 +4,7 @@
 
 <launch>
     <arg name="scenario" default="10x6_central_obstacle" />
-    <arg name="simulation" default="05ms" />
+    <arg name="simulation" default="1ms" />
     <arg name="source_location_x" default="0.50" />
     <arg name="source_location_y" default="3.00" />
     <arg name="source_location_z" default="0.50" />
@@ -77,7 +77,7 @@
 	    <param name="source_position_z" value="$(arg source_location_z)"/>            ### (m)
 	    
 	    <param name="save_results" value="1" />                  #1=true, 0=false
-	    <param name="restuls_time_step" value="0.5" />           #(sec) Time increment between saving state to file
+	    <param name="results_time_step" value="0.5" />           #(sec) Time increment between saving state to file
 	    <param name="results_min_time" value="0.0" />            #(sec) Time to start saving results to file
 	    <param name="results_location" value="$(find test_env)/$(arg scenario)/gas_simulations/$(arg simulation)" />
     </node>

--- a/test_env/10x6_central_obstacle/launch/GADEN_player.launch
+++ b/test_env/10x6_central_obstacle/launch/GADEN_player.launch
@@ -3,7 +3,7 @@
 <launch>  
     
     <arg name="scenario" default="10x6_central_obstacle" />
-    <arg name="simulation" default="05ms" />
+    <arg name="simulation" default="1ms" />
     <arg name="source_location_x" default="0.50" />
     <arg name="source_location_y" default="3.00" />
     <arg name="source_location_z" default="0.50" />

--- a/test_env/10x6_empty_room/launch/GADEN.launch
+++ b/test_env/10x6_empty_room/launch/GADEN.launch
@@ -77,7 +77,7 @@
 	    <param name="source_position_z" value="$(arg source_location_z)"/>            ### (m)
 	    
 	    <param name="save_results" value="1" />                  #1=true, 0=false
-	    <param name="restuls_time_step" value="0.5" />           #(sec) Time increment between saving state to file
+	    <param name="results_time_step" value="0.5" />           #(sec) Time increment between saving state to file
 	    <param name="results_min_time" value="0.0" />            #(sec) Time to start saving results to file
 	    <param name="results_location" value="$(find test_env)/$(arg scenario)/gas_simulations/$(arg simulation)" />
     </node>

--- a/test_env/10x6_maze/launch/GADEN.launch
+++ b/test_env/10x6_maze/launch/GADEN.launch
@@ -4,7 +4,7 @@
 
 <launch>
     <arg name="scenario" default="10x6_maze" />
-    <arg name="simulation" default="05ms" />
+    <arg name="simulation" default="1ms" />
     <arg name="source_location_x" default="0.50" />
     <arg name="source_location_y" default="3.00" />
     <arg name="source_location_z" default="0.50" />
@@ -77,7 +77,7 @@
 	    <param name="source_position_z" value="$(arg source_location_z)"/>            ### (m)
 	    
 	    <param name="save_results" value="1" />                  #1=true, 0=false
-	    <param name="restuls_time_step" value="0.5" />           #(sec) Time increment between saving state to file
+	    <param name="results_time_step" value="0.5" />           #(sec) Time increment between saving state to file
 	    <param name="results_min_time" value="0.0" />            #(sec) Time to start saving results to file
 	    <param name="results_location" value="$(find test_env)/$(arg scenario)/gas_simulations/$(arg simulation)" />
     </node>

--- a/test_env/10x6_maze/launch/GADEN_player.launch
+++ b/test_env/10x6_maze/launch/GADEN_player.launch
@@ -3,7 +3,7 @@
 <launch>  
     
     <arg name="scenario" default="10x6_maze" />
-    <arg name="simulation" default="05ms" />
+    <arg name="simulation" default="1ms" />
     <arg name="source_location_x" default="1.50" />
     <arg name="source_location_y" default="3.00" />
     <arg name="source_location_z" default="0.75" />

--- a/test_env/10x6_snake/launch/GADEN.launch
+++ b/test_env/10x6_snake/launch/GADEN.launch
@@ -77,7 +77,7 @@
 	    <param name="source_position_z" value="$(arg source_location_z)"/>            ### (m)
 	    
 	    <param name="save_results" value="1" />                  #1=true, 0=false
-	    <param name="restuls_time_step" value="0.5" />           #(sec) Time increment between saving state to file
+	    <param name="results_time_step" value="0.5" />           #(sec) Time increment between saving state to file
 	    <param name="results_min_time" value="0.0" />            #(sec) Time to start saving results to file
 	    <param name="results_location" value="$(find test_env)/$(arg scenario)/gas_simulations/$(arg simulation)" />
     </node>

--- a/test_env/MAPIRlab/launch/GADEN.launch
+++ b/test_env/MAPIRlab/launch/GADEN.launch
@@ -77,7 +77,7 @@
 	    <param name="source_position_z" value="$(arg source_location_z)"/>            ### (m)
 	    
 	    <param name="save_results" value="1" />                  #1=true, 0=false
-	    <param name="restuls_time_step" value="0.5" />           #(sec) Time increment between saving state to file
+	    <param name="results_time_step" value="0.5" />           #(sec) Time increment between saving state to file
 	    <param name="results_min_time" value="0.0" />            #(sec) Time to start saving results to file
 	    <param name="results_location" value="$(find test_env)/$(arg scenario)/gas_simulations/$(arg simulation)" />
     </node>


### PR DESCRIPTION
Fixed `results_time_step` typos in launch files for test environments.
Also changed the simulation value in the `GADEN.launch` files to match the corresponding `GADEN_preprocessing.launch` settings.